### PR TITLE
iOS-34 : 이슈 필터링 기능 추가

### DIFF
--- a/iOS/issue-tracker/.swiftlint.yml
+++ b/iOS/issue-tracker/.swiftlint.yml
@@ -2,6 +2,7 @@ disabled_rules:
 - line_length
 - trailing_whitespace
 - vertical_whitespace
+- trailing_comma
 included:
 - issue-tracker
 excluded:

--- a/iOS/issue-tracker/issue-tracker.xcodeproj/project.pbxproj
+++ b/iOS/issue-tracker/issue-tracker.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		5610FF8ABBD23DCD832DAE04 /* Pods_issue_tracker.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C4A228AF8694FA3F29925403 /* Pods_issue_tracker.framework */; };
 		8F334AAB2A0B7E7C0070DDEA /* IssueFilterTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F334AAA2A0B7E7C0070DDEA /* IssueFilterTableViewController.swift */; };
 		8F4456BD2A09E67100EC6B39 /* .swiftlint.yml in Resources */ = {isa = PBXBuildFile; fileRef = 8F4456BC2A09E67100EC6B39 /* .swiftlint.yml */; };
+		8F5204FB2A1DDF4900B49CF0 /* FilterOptionListMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F5204FA2A1DDF4900B49CF0 /* FilterOptionListMock.swift */; };
 		8F61EB262A1642ED0020E302 /* State.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F61EB252A1642ED0020E302 /* State.swift */; };
 		8F61EB282A1648B90020E302 /* IssueFrame.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F61EB272A1648B90020E302 /* IssueFrame.swift */; };
 		8FB11D842A18D8BC00EDEE45 /* NetworkManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8FB11D832A18D8BC00EDEE45 /* NetworkManager.swift */; };
@@ -47,6 +48,7 @@
 		6FA8EEB52250DFCA5841EF77 /* Pods-issue-tracker.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-issue-tracker.release.xcconfig"; path = "Target Support Files/Pods-issue-tracker/Pods-issue-tracker.release.xcconfig"; sourceTree = "<group>"; };
 		8F334AAA2A0B7E7C0070DDEA /* IssueFilterTableViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueFilterTableViewController.swift; sourceTree = "<group>"; };
 		8F4456BC2A09E67100EC6B39 /* .swiftlint.yml */ = {isa = PBXFileReference; lastKnownFileType = text.yaml; path = .swiftlint.yml; sourceTree = "<group>"; };
+		8F5204FA2A1DDF4900B49CF0 /* FilterOptionListMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterOptionListMock.swift; sourceTree = "<group>"; };
 		8F61EB252A1642ED0020E302 /* State.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = State.swift; sourceTree = "<group>"; };
 		8F61EB272A1648B90020E302 /* IssueFrame.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueFrame.swift; sourceTree = "<group>"; };
 		8FB11D832A18D8BC00EDEE45 /* NetworkManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkManager.swift; sourceTree = "<group>"; };
@@ -220,6 +222,7 @@
 				8F61EB272A1648B90020E302 /* IssueFrame.swift */,
 				8FB11D852A18E72E00EDEE45 /* IssueFrameHolder.swift */,
 				8FB11D8A2A1C530E00EDEE45 /* FilterOption.swift */,
+				8F5204FA2A1DDF4900B49CF0 /* FilterOptionListMock.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -392,6 +395,7 @@
 				E4D8AD672A1616AA005BA9BA /* Author.swift in Sources */,
 				8FBE800B2A0B8D8B00D9DA1A /* IssueFilterTableViewCell.swift in Sources */,
 				E48278652A09DAC800E91FA3 /* SceneDelegate.swift in Sources */,
+				8F5204FB2A1DDF4900B49CF0 /* FilterOptionListMock.swift in Sources */,
 				E4D8AD652A161692005BA9BA /* Label.swift in Sources */,
 				E48278A02A0C8AEC00E91FA3 /* IssueCollectionViewHeaderCell.swift in Sources */,
 				E482787C2A09EA3400E91FA3 /* HomeViewController.swift in Sources */,

--- a/iOS/issue-tracker/issue-tracker/Home/Issue/Controllers/IssueFilterTableViewController.swift
+++ b/iOS/issue-tracker/issue-tracker/Home/Issue/Controllers/IssueFilterTableViewController.swift
@@ -95,39 +95,6 @@ class IssueFilterTableViewController: UITableViewController {
     }
 }
 
-struct FilterOptionListMock: FilterOptionsLike {
-    var list: [[FilterOption]] = [
-        [
-            FilterOption(filterLabel: "열린 이슈", filterUrlStr: nil),
-            FilterOption(filterLabel: "내가 작성한 이슈", filterUrlStr: nil),
-            FilterOption(filterLabel: "내가 댓글을 남긴 이슈", filterUrlStr: nil),
-            FilterOption(filterLabel: "닫힌 이슈", filterUrlStr: "{close=true}", isSelected: false)
-        ],
-        [
-            FilterOption(filterLabel: "chloe", filterUrlStr: nil),
-            FilterOption(filterLabel: "head", filterUrlStr: nil),
-            FilterOption(filterLabel: "sam", filterUrlStr: nil),
-            FilterOption(filterLabel: "zello", filterUrlStr: nil)
-        ],
-        [
-            FilterOption(filterLabel: "레이블 없음", filterUrlStr: nil, isSelected: false),
-            FilterOption(filterLabel: "그룹프로젝트:이슈트래커", filterUrlStr: nil, isSelected: false)
-        ]
-    ]
-    
-    func collectSelectedFilterOptionUrlString() -> String {
-        var collectedOptionUrlString = "?"
-        
-        for options in list {
-            for option in options {
-                guard let urlStr = option.filterUrlStr else { continue }
-                collectedOptionUrlString += option.isSelected ? urlStr : ""
-            }
-        }
-        return collectedOptionUrlString.count == 1 ? "" : collectedOptionUrlString
-    }
-}
-
 protocol FilterOptionsLike {
     var list: [[FilterOption]] { get set }
     func collectSelectedFilterOptionUrlString() -> String

--- a/iOS/issue-tracker/issue-tracker/Home/Issue/Controllers/IssueFilterTableViewController.swift
+++ b/iOS/issue-tracker/issue-tracker/Home/Issue/Controllers/IssueFilterTableViewController.swift
@@ -8,10 +8,9 @@
 import UIKit
 
 class IssueFilterTableViewController: UITableViewController {
-    
-
     private let checkmarkImage = UIImage(systemName: "checkmark")
     private let grayCheckmarkImage = UIImage(systemName: "checkmark")?.withTintColor(.gray, renderingMode: .alwaysOriginal)
+    var filterOptionList: FilterOptionsLike = FilterOptionListMock()
     weak var delegate: IssueTabViewController?
     
     override func viewDidLoad() {
@@ -22,11 +21,11 @@ class IssueFilterTableViewController: UITableViewController {
         configureBackButton()
         configureSaveButton()
     }
-
+    
     override func numberOfSections(in tableView: UITableView) -> Int {
         return 3
     }
-
+    
     override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         switch section {
         case 0: return 4
@@ -35,11 +34,11 @@ class IssueFilterTableViewController: UITableViewController {
         default: return 1
         }
     }
-
+    
     override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         
         guard let cell = tableView.dequeueReusableCell(withIdentifier: "filterOptionCell", for: indexPath) as? IssueFilterTableViewCell else { return UITableViewCell() }
-        cell.configureWith(filterOption: FilterOption(filterLabel: "Test", filterUrlStr: nil), selectedImage: checkmarkImage, deselectedImage: grayCheckmarkImage)
+        cell.configureWith(filterOption: filterOptionList.list[indexPath.section][indexPath.row], selectedImage: checkmarkImage, deselectedImage: grayCheckmarkImage)
         return cell
     }
     
@@ -51,7 +50,7 @@ class IssueFilterTableViewController: UITableViewController {
     }
     
     override func tableView(_ tableView: UITableView, titleForHeaderInSection
-                                section: Int) -> String? {
+                            section: Int) -> String? {
         switch section {
         case 0: return "상태"
         case 1: return "담당자"
@@ -92,4 +91,29 @@ class IssueFilterTableViewController: UITableViewController {
     private func dismissSelf() {
         navigationController?.popViewController(animated: true)
     }
+}
+
+struct FilterOptionListMock: FilterOptionsLike {
+    let list: [[FilterOption]] = [
+        [
+            FilterOption(filterLabel: "열린 이슈", filterUrlStr: nil),
+            FilterOption(filterLabel: "내가 작성한 이슈", filterUrlStr: nil),
+            FilterOption(filterLabel: "내가 댓글을 남긴 이슈", filterUrlStr: nil),
+            FilterOption(filterLabel: "닫힌 이슈", filterUrlStr: "?{close=true}"),
+        ],
+        [
+            FilterOption(filterLabel: "chloe", filterUrlStr: nil),
+            FilterOption(filterLabel: "head", filterUrlStr: nil),
+            FilterOption(filterLabel: "sam", filterUrlStr: nil),
+            FilterOption(filterLabel: "zello", filterUrlStr: nil),
+        ],
+        [
+            FilterOption(filterLabel: "레이블 없음", filterUrlStr: nil),
+            FilterOption(filterLabel: "그룹프로젝트:이슈트래커", filterUrlStr: nil),
+        ],
+    ]
+}
+
+protocol FilterOptionsLike {
+    var list: [[FilterOption]] { get }
 }

--- a/iOS/issue-tracker/issue-tracker/Home/Issue/Controllers/IssueFilterTableViewController.swift
+++ b/iOS/issue-tracker/issue-tracker/Home/Issue/Controllers/IssueFilterTableViewController.swift
@@ -28,9 +28,9 @@ class IssueFilterTableViewController: UITableViewController {
     
     override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         switch section {
-        case 0: return 4
-        case 1: return 4
-        case 2: return 2
+        case 0: return filterOptionList.list[0].count
+        case 1: return filterOptionList.list[1].count
+        case 2: return filterOptionList.list[2].count
         default: return 1
         }
     }

--- a/iOS/issue-tracker/issue-tracker/Home/Issue/Controllers/IssueFilterTableViewController.swift
+++ b/iOS/issue-tracker/issue-tracker/Home/Issue/Controllers/IssueFilterTableViewController.swift
@@ -101,18 +101,18 @@ struct FilterOptionListMock: FilterOptionsLike {
             FilterOption(filterLabel: "열린 이슈", filterUrlStr: nil),
             FilterOption(filterLabel: "내가 작성한 이슈", filterUrlStr: nil),
             FilterOption(filterLabel: "내가 댓글을 남긴 이슈", filterUrlStr: nil),
-            FilterOption(filterLabel: "닫힌 이슈", filterUrlStr: "{close=true}", isSelected: false),
+            FilterOption(filterLabel: "닫힌 이슈", filterUrlStr: "{close=true}", isSelected: false)
         ],
         [
             FilterOption(filterLabel: "chloe", filterUrlStr: nil),
             FilterOption(filterLabel: "head", filterUrlStr: nil),
             FilterOption(filterLabel: "sam", filterUrlStr: nil),
-            FilterOption(filterLabel: "zello", filterUrlStr: nil),
+            FilterOption(filterLabel: "zello", filterUrlStr: nil)
         ],
         [
             FilterOption(filterLabel: "레이블 없음", filterUrlStr: nil, isSelected: false),
-            FilterOption(filterLabel: "그룹프로젝트:이슈트래커", filterUrlStr: nil, isSelected: false),
-        ],
+            FilterOption(filterLabel: "그룹프로젝트:이슈트래커", filterUrlStr: nil, isSelected: false)
+        ]
     ]
     
     func collectSelectedFilterOptionUrlString() -> String {

--- a/iOS/issue-tracker/issue-tracker/Home/Issue/Controllers/IssueFilterTableViewController.swift
+++ b/iOS/issue-tracker/issue-tracker/Home/Issue/Controllers/IssueFilterTableViewController.swift
@@ -65,6 +65,23 @@ class IssueFilterTableViewController: UITableViewController {
         return num
     }
     
+    private func dismissSelf() {
+        navigationController?.popViewController(animated: true)
+    }
+}
+
+protocol FilterOptionsLike {
+    var list: [[FilterOption]] { get set }
+    func collectSelectedFilterOptionUrlString() -> String
+}
+
+protocol IssueTabViewControllerLike {
+    func setUrlString(with: String)
+    func fetchData()
+}
+
+// 취소, 저장 버튼
+extension IssueFilterTableViewController {
     private func configureBackButton() {
         let backbutton = UIButton(type: .custom)
         backbutton.setImage(UIImage(systemName: "chevron.left"), for: .normal)
@@ -89,18 +106,4 @@ class IssueFilterTableViewController: UITableViewController {
         delegate?.fetchData()
         dismissSelf()
     }
-    
-    private func dismissSelf() {
-        navigationController?.popViewController(animated: true)
-    }
-}
-
-protocol FilterOptionsLike {
-    var list: [[FilterOption]] { get set }
-    func collectSelectedFilterOptionUrlString() -> String
-}
-
-protocol IssueTabViewControllerLike {
-    func setUrlString(with: String)
-    func fetchData()
 }

--- a/iOS/issue-tracker/issue-tracker/Home/Issue/Controllers/IssueFilterTableViewController.swift
+++ b/iOS/issue-tracker/issue-tracker/Home/Issue/Controllers/IssueFilterTableViewController.swift
@@ -39,7 +39,7 @@ class IssueFilterTableViewController: UITableViewController {
     override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         
         guard let cell = tableView.dequeueReusableCell(withIdentifier: "filterOptionCell", for: indexPath) as? IssueFilterTableViewCell else { return UITableViewCell() }
-        cell.configureWith(optionName: "Filter option", selectedImage: checkmarkImage, deselectedImage: grayCheckmarkImage)
+        cell.configureWith(filterOption: FilterOption(filterLabel: "Test", filterUrlStr: nil), selectedImage: checkmarkImage, deselectedImage: grayCheckmarkImage)
         return cell
     }
     

--- a/iOS/issue-tracker/issue-tracker/Home/Issue/Controllers/IssueFilterTableViewController.swift
+++ b/iOS/issue-tracker/issue-tracker/Home/Issue/Controllers/IssueFilterTableViewController.swift
@@ -10,7 +10,7 @@ import UIKit
 class IssueFilterTableViewController: UITableViewController {
     private let checkmarkImage = UIImage(systemName: "checkmark")
     private let grayCheckmarkImage = UIImage(systemName: "checkmark")?.withTintColor(.gray, renderingMode: .alwaysOriginal)
-    var filterOptionList: FilterOptionsLike = FilterOptionListMock()
+    var filterOptionList: FilterOptionsLike?
     weak var delegate: IssueTabViewController?
     
     override func viewDidLoad() {
@@ -28,24 +28,25 @@ class IssueFilterTableViewController: UITableViewController {
     
     override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         switch section {
-        case 0: return filterOptionList.list[0].count
-        case 1: return filterOptionList.list[1].count
-        case 2: return filterOptionList.list[2].count
+        case 0: return filterOptionList?.list[0].count ?? 1
+        case 1: return filterOptionList?.list[1].count ?? 1
+        case 2: return filterOptionList?.list[2].count ?? 1
         default: return 1
         }
     }
     
     override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-                guard let cell = tableView.dequeueReusableCell(withIdentifier: "filterOptionCell", for: indexPath) as? IssueFilterTableViewCell else { return UITableViewCell() }
-        cell.configureWith(filterOption: filterOptionList.list[indexPath.section][indexPath.row], selectedImage: checkmarkImage, deselectedImage: grayCheckmarkImage)
-                return cell
+        guard let cell = tableView.dequeueReusableCell(withIdentifier: "filterOptionCell", for: indexPath) as? IssueFilterTableViewCell else { return UITableViewCell() }
+        guard let filterOption = filterOptionList?.list[indexPath.section][indexPath.row] else { return UITableViewCell() }
+        cell.configureWith(filterOption: filterOption, selectedImage: checkmarkImage, deselectedImage: grayCheckmarkImage)
+        return cell
     }
     
     override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         tableView.deselectRow(at: indexPath, animated: true)
         if let cell = tableView.cellForRow(at: indexPath) as? IssueFilterTableViewCell {
             cell.toggleSelecting()
-            filterOptionList.list[indexPath.section][indexPath.row].isSelected.toggle()
+            filterOptionList?.list[indexPath.section][indexPath.row].isSelected.toggle()
         }
     }
     
@@ -101,9 +102,9 @@ extension IssueFilterTableViewController {
     }
     
     @objc func saveAction() {
-        let newUrlString = filterOptionList.collectSelectedFilterOptionUrlString()
+        let filterUrlString = delegate?.filterOptionList.collectSelectedFilterOptionUrlString() ?? ""
+        let newUrlString = "http://3.38.73.117:8080/api-ios/issues" + filterUrlString
         delegate?.setUrlString(with: newUrlString)
-        delegate?.fetchData()
         dismissSelf()
     }
 }

--- a/iOS/issue-tracker/issue-tracker/Home/Issue/Controllers/IssueFilterTableViewController.swift
+++ b/iOS/issue-tracker/issue-tracker/Home/Issue/Controllers/IssueFilterTableViewController.swift
@@ -36,16 +36,16 @@ class IssueFilterTableViewController: UITableViewController {
     }
     
     override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        
-        guard let cell = tableView.dequeueReusableCell(withIdentifier: "filterOptionCell", for: indexPath) as? IssueFilterTableViewCell else { return UITableViewCell() }
+                guard let cell = tableView.dequeueReusableCell(withIdentifier: "filterOptionCell", for: indexPath) as? IssueFilterTableViewCell else { return UITableViewCell() }
         cell.configureWith(filterOption: filterOptionList.list[indexPath.section][indexPath.row], selectedImage: checkmarkImage, deselectedImage: grayCheckmarkImage)
-        return cell
+                return cell
     }
     
     override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         tableView.deselectRow(at: indexPath, animated: true)
         if let cell = tableView.cellForRow(at: indexPath) as? IssueFilterTableViewCell {
             cell.toggleSelecting()
+            filterOptionList.list[indexPath.section][indexPath.row].isSelected.toggle()
         }
     }
     
@@ -84,6 +84,8 @@ class IssueFilterTableViewController: UITableViewController {
     }
     
     @objc func saveAction() {
+        let newUrlString = filterOptionList.collectSelectedFilterOptionUrlString()
+        delegate?.setUrlString(with: newUrlString)
         delegate?.fetchData()
         dismissSelf()
     }
@@ -94,12 +96,12 @@ class IssueFilterTableViewController: UITableViewController {
 }
 
 struct FilterOptionListMock: FilterOptionsLike {
-    let list: [[FilterOption]] = [
+    var list: [[FilterOption]] = [
         [
             FilterOption(filterLabel: "열린 이슈", filterUrlStr: nil),
             FilterOption(filterLabel: "내가 작성한 이슈", filterUrlStr: nil),
             FilterOption(filterLabel: "내가 댓글을 남긴 이슈", filterUrlStr: nil),
-            FilterOption(filterLabel: "닫힌 이슈", filterUrlStr: "?{close=true}", isSelected: false),
+            FilterOption(filterLabel: "닫힌 이슈", filterUrlStr: "{close=true}", isSelected: false),
         ],
         [
             FilterOption(filterLabel: "chloe", filterUrlStr: nil),
@@ -112,8 +114,21 @@ struct FilterOptionListMock: FilterOptionsLike {
             FilterOption(filterLabel: "그룹프로젝트:이슈트래커", filterUrlStr: nil, isSelected: false),
         ],
     ]
+    
+    func collectSelectedFilterOptionUrlString() -> String {
+        var collectedOptionUrlString = "?"
+        
+        for options in list {
+            for option in options {
+                guard let urlStr = option.filterUrlStr else { continue }
+                collectedOptionUrlString += option.isSelected ? urlStr : ""
+            }
+        }
+        return collectedOptionUrlString.count == 1 ? "" : collectedOptionUrlString
+    }
 }
 
 protocol FilterOptionsLike {
-    var list: [[FilterOption]] { get }
+    var list: [[FilterOption]] { get set }
+    func collectSelectedFilterOptionUrlString() -> String
 }

--- a/iOS/issue-tracker/issue-tracker/Home/Issue/Controllers/IssueFilterTableViewController.swift
+++ b/iOS/issue-tracker/issue-tracker/Home/Issue/Controllers/IssueFilterTableViewController.swift
@@ -132,3 +132,8 @@ protocol FilterOptionsLike {
     var list: [[FilterOption]] { get set }
     func collectSelectedFilterOptionUrlString() -> String
 }
+
+protocol IssueTabViewControllerLike {
+    func setUrlString(with: String)
+    func fetchData()
+}

--- a/iOS/issue-tracker/issue-tracker/Home/Issue/Controllers/IssueFilterTableViewController.swift
+++ b/iOS/issue-tracker/issue-tracker/Home/Issue/Controllers/IssueFilterTableViewController.swift
@@ -99,7 +99,7 @@ struct FilterOptionListMock: FilterOptionsLike {
             FilterOption(filterLabel: "열린 이슈", filterUrlStr: nil),
             FilterOption(filterLabel: "내가 작성한 이슈", filterUrlStr: nil),
             FilterOption(filterLabel: "내가 댓글을 남긴 이슈", filterUrlStr: nil),
-            FilterOption(filterLabel: "닫힌 이슈", filterUrlStr: "?{close=true}"),
+            FilterOption(filterLabel: "닫힌 이슈", filterUrlStr: "?{close=true}", isSelected: false),
         ],
         [
             FilterOption(filterLabel: "chloe", filterUrlStr: nil),
@@ -108,8 +108,8 @@ struct FilterOptionListMock: FilterOptionsLike {
             FilterOption(filterLabel: "zello", filterUrlStr: nil),
         ],
         [
-            FilterOption(filterLabel: "레이블 없음", filterUrlStr: nil),
-            FilterOption(filterLabel: "그룹프로젝트:이슈트래커", filterUrlStr: nil),
+            FilterOption(filterLabel: "레이블 없음", filterUrlStr: nil, isSelected: false),
+            FilterOption(filterLabel: "그룹프로젝트:이슈트래커", filterUrlStr: nil, isSelected: false),
         ],
     ]
 }

--- a/iOS/issue-tracker/issue-tracker/Home/Issue/Controllers/IssueTabViewController.swift
+++ b/iOS/issue-tracker/issue-tracker/Home/Issue/Controllers/IssueTabViewController.swift
@@ -14,6 +14,7 @@ class IssueTabViewController: UIViewController {
     @IBOutlet var collectionView: IssueCollectionView!
     var cancelButton: UIBarButtonItem?
     let nothingButton = UIBarButtonItem(title: "", style: .plain, target: nil, action: nil)
+    var filterOptionList: FilterOptionsLike = FilterOptionListMock()
     
     let fetcher = HTTPDataFetcher()
     
@@ -39,6 +40,8 @@ class IssueTabViewController: UIViewController {
     
     @IBAction func filterButtonTouched(_ sender: UIButton) {
         let filterTableViewController = IssueFilterTableViewController()
+        filterTableViewController.delegate = self
+        filterTableViewController.filterOptionList = filterOptionList
         show(filterTableViewController, sender: sender)
     }
     

--- a/iOS/issue-tracker/issue-tracker/Home/Issue/Controllers/IssueTabViewController.swift
+++ b/iOS/issue-tracker/issue-tracker/Home/Issue/Controllers/IssueTabViewController.swift
@@ -9,7 +9,6 @@ import UIKit
 import OSLog
 
 class IssueTabViewController: UIViewController {
-    
     @IBOutlet var filterButton: UIBarButtonItem!
     @IBOutlet var selectButton: UIBarButtonItem!
     @IBOutlet var collectionView: IssueCollectionView!
@@ -27,21 +26,11 @@ class IssueTabViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        // TODO: fetchData(with: String)로 대체 예정
-        networkManager.fetchIssueData { result in
-            switch result {
-            case .success(let issueFrameHolder):
-                self.issueFrames = issueFrameHolder.issues
-                guard let issueFrames = self.issueFrames else { return }
-                self.collectionView.issueFrames = issueFrames
-                DispatchQueue.main.async {
-                    self.collectionView.reloadData()
-                }
-            case .failure(let error):
-                self.logger.error("error : \(error)")
-            }
-        }
         setCancelButton()
+    }
+    
+    override func viewWillAppear(_ animated: Bool) {
+        fetchData()
     }
     
     private func setCancelButton() {
@@ -54,7 +43,6 @@ class IssueTabViewController: UIViewController {
     }
     
     @IBAction func selectButtonTouched(_ sender: UIButton) {
-        
         self.navigationController?.isToolbarHidden = false
         self.tabBarController?.tabBar.isHidden = true
         self.navigationItem.leftBarButtonItem = nothingButton
@@ -69,13 +57,12 @@ class IssueTabViewController: UIViewController {
         self.navigationItem.rightBarButtonItem = selectButton
     }
     
-    func fetchData() {
+    private func fetchData() {
         guard let url = URL(string: currentIssueDataUrlString) else {
             self.logger.log(
                 "Invalie URL string : \(self.currentIssueDataUrlString)")
             return
         }
-        
         networkManager.fetchIssueData(with: url) { result in
             switch result {
             case .success(let issueFrameHolder):
@@ -95,5 +82,3 @@ class IssueTabViewController: UIViewController {
         currentIssueDataUrlString = urlString
     }
 }
-
-

--- a/iOS/issue-tracker/issue-tracker/Home/Issue/Models/FilterOption.swift
+++ b/iOS/issue-tracker/issue-tracker/Home/Issue/Models/FilterOption.swift
@@ -10,4 +10,11 @@ import Foundation
 struct FilterOption {
     let filterLabel: String
     let filterUrlStr: String?
+    var isSelected: Bool
+    
+    init(filterLabel: String, filterUrlStr: String?, isSelected: Bool = true) {
+        self.filterLabel = filterLabel
+        self.filterUrlStr = filterUrlStr
+        self.isSelected = isSelected
+    }
 }

--- a/iOS/issue-tracker/issue-tracker/Home/Issue/Models/FilterOption.swift
+++ b/iOS/issue-tracker/issue-tracker/Home/Issue/Models/FilterOption.swift
@@ -12,7 +12,7 @@ struct FilterOption {
     let filterUrlStr: String?
     var isSelected: Bool
     
-    init(filterLabel: String, filterUrlStr: String?, isSelected: Bool = true) {
+    init(filterLabel: String, filterUrlStr: String?, isSelected: Bool = false) {
         self.filterLabel = filterLabel
         self.filterUrlStr = filterUrlStr
         self.isSelected = isSelected

--- a/iOS/issue-tracker/issue-tracker/Home/Issue/Models/FilterOptionListMock.swift
+++ b/iOS/issue-tracker/issue-tracker/Home/Issue/Models/FilterOptionListMock.swift
@@ -10,32 +10,46 @@ import Foundation
 class FilterOptionListMock: FilterOptionsLike {
     var list: [[FilterOption]] = [
         [
-            FilterOption(filterLabel: "열린 이슈", filterUrlStr: nil),
+            FilterOption(filterLabel: "열린 이슈", filterUrlStr: "state=true"),
             FilterOption(filterLabel: "내가 작성한 이슈", filterUrlStr: nil),
             FilterOption(filterLabel: "내가 댓글을 남긴 이슈", filterUrlStr: nil),
-            FilterOption(filterLabel: "닫힌 이슈", filterUrlStr: "{close=true}", isSelected: false)
+            FilterOption(filterLabel: "닫힌 이슈", filterUrlStr: "state=false"),
         ],
         [
-            FilterOption(filterLabel: "chloe", filterUrlStr: nil),
-            FilterOption(filterLabel: "head", filterUrlStr: nil),
-            FilterOption(filterLabel: "sam", filterUrlStr: nil),
-            FilterOption(filterLabel: "zello", filterUrlStr: nil)
+            // 현재 assignee의 id로 필터링 가능, 중첩 사용은 안됌
+            FilterOption(filterLabel: "ghkdgus29", filterUrlStr: "assignee=ghkdgus29"),
+            FilterOption(filterLabel: "cire", filterUrlStr: "assignee=cire"),
         ],
         [
-            FilterOption(filterLabel: "레이블 없음", filterUrlStr: nil, isSelected: false),
-            FilterOption(filterLabel: "그룹프로젝트:이슈트래커", filterUrlStr: nil, isSelected: false)
+            FilterOption(filterLabel: "레이블 없음", filterUrlStr: nil),
+            FilterOption(filterLabel: "BE STEP1", filterUrlStr: nil),
         ]
     ]
     
     func collectSelectedFilterOptionUrlString() -> String {
+        // 필터 적용 형태 : 기본 URL + ?key1=value1&key2=value2
+        // labelNames의 경우 : 기본 URL + ?라벨이름키=라벨1,라벨2
         var collectedOptionUrlString = "?"
         
-        for options in list {
-            for option in options {
+        var urlString = ""
+        for index in 0...1 {
+            for option in list[index] {
                 guard let urlStr = option.filterUrlStr else { continue }
-                collectedOptionUrlString += option.isSelected ? urlStr : ""
+                collectedOptionUrlString += option.isSelected ? urlStr + "&" : ""
             }
         }
+        _ = urlString.popLast()
+        
+        var labelUrlString = ""
+        for option in list[2] {
+            guard let urlStr = option.filterUrlStr else { continue }
+            collectedOptionUrlString += option.isSelected ? urlStr + "," : ""
+        }
+        _ = labelUrlString.popLast()
+        
+        collectedOptionUrlString += urlString
+        collectedOptionUrlString += labelUrlString
+        
         return collectedOptionUrlString.count == 1 ? "" : collectedOptionUrlString
     }
 }

--- a/iOS/issue-tracker/issue-tracker/Home/Issue/Models/FilterOptionListMock.swift
+++ b/iOS/issue-tracker/issue-tracker/Home/Issue/Models/FilterOptionListMock.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-struct FilterOptionListMock: FilterOptionsLike {
+class FilterOptionListMock: FilterOptionsLike {
     var list: [[FilterOption]] = [
         [
             FilterOption(filterLabel: "열린 이슈", filterUrlStr: nil),

--- a/iOS/issue-tracker/issue-tracker/Home/Issue/Models/FilterOptionListMock.swift
+++ b/iOS/issue-tracker/issue-tracker/Home/Issue/Models/FilterOptionListMock.swift
@@ -1,0 +1,41 @@
+//
+//  FilterOptionListMock.swift
+//  issue-tracker
+//
+//  Created by 에디 on 2023/05/24.
+//
+
+import Foundation
+
+struct FilterOptionListMock: FilterOptionsLike {
+    var list: [[FilterOption]] = [
+        [
+            FilterOption(filterLabel: "열린 이슈", filterUrlStr: nil),
+            FilterOption(filterLabel: "내가 작성한 이슈", filterUrlStr: nil),
+            FilterOption(filterLabel: "내가 댓글을 남긴 이슈", filterUrlStr: nil),
+            FilterOption(filterLabel: "닫힌 이슈", filterUrlStr: "{close=true}", isSelected: false)
+        ],
+        [
+            FilterOption(filterLabel: "chloe", filterUrlStr: nil),
+            FilterOption(filterLabel: "head", filterUrlStr: nil),
+            FilterOption(filterLabel: "sam", filterUrlStr: nil),
+            FilterOption(filterLabel: "zello", filterUrlStr: nil)
+        ],
+        [
+            FilterOption(filterLabel: "레이블 없음", filterUrlStr: nil, isSelected: false),
+            FilterOption(filterLabel: "그룹프로젝트:이슈트래커", filterUrlStr: nil, isSelected: false)
+        ]
+    ]
+    
+    func collectSelectedFilterOptionUrlString() -> String {
+        var collectedOptionUrlString = "?"
+        
+        for options in list {
+            for option in options {
+                guard let urlStr = option.filterUrlStr else { continue }
+                collectedOptionUrlString += option.isSelected ? urlStr : ""
+            }
+        }
+        return collectedOptionUrlString.count == 1 ? "" : collectedOptionUrlString
+    }
+}

--- a/iOS/issue-tracker/issue-tracker/Home/Issue/Views/IssueFilterTableViewCell.swift
+++ b/iOS/issue-tracker/issue-tracker/Home/Issue/Views/IssueFilterTableViewCell.swift
@@ -11,6 +11,7 @@ class IssueFilterTableViewCell: UITableViewCell {
 
     @IBOutlet var filterOptionLabel: UILabel!
     @IBOutlet var togglableImageView: UIImageView!
+    var filterOption: FilterOption?
     var isOptionSelected = false {
         willSet {
             togglableImageView.image = newValue ? selectedImage : deselectedImage
@@ -23,8 +24,8 @@ class IssueFilterTableViewCell: UITableViewCell {
         super.awakeFromNib()
     }
     
-    func configureWith(optionName: String, selectedImage: UIImage?, deselectedImage: UIImage?) {
-        filterOptionLabel.text = optionName
+    func configureWith(filterOption: FilterOption, selectedImage: UIImage?, deselectedImage: UIImage?) {
+        filterOptionLabel.text = filterOption.filterLabel
         self.selectedImage = selectedImage
         self.deselectedImage = deselectedImage
         togglableImageView.image = deselectedImage

--- a/iOS/issue-tracker/issue-tracker/Home/Issue/Views/IssueFilterTableViewCell.swift
+++ b/iOS/issue-tracker/issue-tracker/Home/Issue/Views/IssueFilterTableViewCell.swift
@@ -28,7 +28,7 @@ class IssueFilterTableViewCell: UITableViewCell {
         filterOptionLabel.text = filterOption.filterLabel
         self.selectedImage = selectedImage
         self.deselectedImage = deselectedImage
-        togglableImageView.image = deselectedImage
+        isOptionSelected = filterOption.isSelected
     }
     
     func toggleSelecting() {


### PR DESCRIPTION
#34 이슈 반영 내용입니다.

# 주요 작업 내용
- 선택된 필터 옵션에 따라 이슈 목록을 조회하는 기능을 추가했습니다.

# 고민하고 선택한 부분
- 선택된 필터 옵션을 어떻게 알 수 있을까에 대해 고민했습니다. 처음에는 tableView의 select, deselect 관련 메소드를 활용하려 했습니다. 하지만 예상과 다르게 select와 deselect 메소드는 토글 방식으로 실행되는 메소드가 아니였습니다. 이 때문에 FilterOption이라는 자체 타입을 선언하고, 이들을 저장하는 데이터 타입을 만들어야 했습니다.
- 선택된 필터 옵션을 저장하기 위해, 이슈 탭 컨트롤러가 해당하는 데이터를 갖고 있도록 했습니다. 필터 옵션을 선택하는 뷰에 참조를 전달하는 방식으로 동작하도록 했습니다.