### PR TITLE
[iOS-57] 이슈의 라벨이 여러개 생성되던 버그 픽스

### DIFF
--- a/iOS/issue-tracker/issue-tracker/Home/Issue/Controllers/IssueTabViewController.swift
+++ b/iOS/issue-tracker/issue-tracker/Home/Issue/Controllers/IssueTabViewController.swift
@@ -35,6 +35,10 @@ class IssueTabViewController: UIViewController {
         setAddIssueButton()
     }
     
+    override func viewWillAppear(_ animated: Bool) {
+        fetchData()
+    }
+    
     private func setAddIssueButton() {
         addIssueButton = AddIssueButton(radius: self.view.frame.height * 56 / 666)
         guard let addIssueButton = addIssueButton else {
@@ -71,10 +75,6 @@ class IssueTabViewController: UIViewController {
             return
         }
         self.view.addSubview(toolBar)
-    }
-    
-    override func viewWillAppear(_ animated: Bool) {
-        fetchData()
     }
     
     private func setCancelButton() {

--- a/iOS/issue-tracker/issue-tracker/Home/Issue/Views/IssueCollectionViewCell.swift
+++ b/iOS/issue-tracker/issue-tracker/Home/Issue/Views/IssueCollectionViewCell.swift
@@ -27,6 +27,12 @@ class IssueCollectionViewCell: SwipeCollectionViewCell {
         setMilestoneImage()
         setMilestone()
     }
+    
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        labelsStackView.arrangedSubviews.forEach { view in view.removeFromSuperview() }
+    }
+    
     private func setTitle() {
         title.text = "iOS 이슈트래커 개발"
         


### PR DESCRIPTION
prepareForReuse, removeViewFromSuperview 메소드를 사용했습니다.
위 메소드들을 통해 이전 dequeue작업에서 configure로 추가된 subview들을 제거할 수 있었습니다.